### PR TITLE
Set the additional ref script fee to zero before the conway era

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liqwid-labs/lucid",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "MIT",
   "author": "Alessandro Konrad",
   "description": "Lucid is a library, which allows you to create Cardano transactions and off-chain code for your Plutus contracts in JavaScript, Deno and Node.js.",

--- a/src/provider/blockfrost.ts
+++ b/src/provider/blockfrost.ts
@@ -47,7 +47,11 @@ export class Blockfrost implements Provider {
       maxCollateralInputs: parseInt(result.max_collateral_inputs),
       costModels: result.cost_models,
       minFeeReferenceScripts: {
-        base: result.min_fee_ref_script_cost_per_byte,
+        // NOTE: these parameters (and the corresponding fee for reference
+        // scripts) have been introduced with the Chang hard fork and do not
+        // apply before the Conway era. The `base` is a multiplier, so setting
+        // it to zero is equivalent to not adding the reference scripts fee.
+        base: result.min_fee_ref_script_cost_per_byte ?? 0,
         range: 25_600, // FIXME: Blockfrost doesn't seem to provide this parameter (Ogmios does)
         multiplier: 1.2, // FIXME: Blockfrost doesn't seem to provide this parameter (Ogmios does)
       },

--- a/src/provider/kupmios.ts
+++ b/src/provider/kupmios.ts
@@ -68,7 +68,16 @@ export class Kupmios implements Provider {
               collateralPercentage: parseInt(result.collateralPercentage),
               maxCollateralInputs: parseInt(result.maxCollateralInputs),
               costModels,
-              minFeeReferenceScripts: result.minFeeReferenceScripts
+              minFeeReferenceScripts: result.minFeeReferenceScripts ?? {
+                // NOTE: these parameters (and the corresponding fee for
+                // reference scripts) have been introduced with the Chang hard
+                // fork and do not apply before the Conway era. Setting either
+                // `base` or `multiplier` to zero is equivalent to not adding
+                // the reference scripts fee.
+                base: 0,
+                range: 1,
+                multiplier: 0
+              }
             },
           );
           client.close();


### PR DESCRIPTION
When the parameters introduced with the new Chang hard fork are not provided (as is the case for Mainnet before the hard fork happens), this PR sets the `minFeeRefScriptCostPerBytes` parameter to zero, effectively removing the new fee.